### PR TITLE
set exact=False by default

### DIFF
--- a/mockserver/__init__.py
+++ b/mockserver/__init__.py
@@ -119,6 +119,7 @@ class MockServerClient(object):
                 is matched as "greater than or equal to"
         """
         count = 1 if count is None else count
+        exact = False if exact is None else exact
         resp = self._put("/verify", {
             "httpRequest": request,
             "times": {

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="mockserver-client",
-    version="0.0.1",
+    version="0.0.2",
     packages=setuptools.find_packages(),
     author='Job Evers-Meltzer',
     author_email='jobevers@gmail.com',


### PR DESCRIPTION
reason: mockserver 3.11 (released 3 days ago) does not accept exact=None anymore